### PR TITLE
120x faster write_profile through buffered I/O & non-pretty printing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ mod internal {
     use serde_json;
     use std::cell::RefCell;
     use std::fs::File;
+    use std::io::BufWriter;
     use std::sync::mpsc::{channel, Sender, Receiver};
     use std::sync::Mutex;
     use std::thread;
@@ -139,8 +140,8 @@ mod internal {
                 }));
             }
 
-            let f = File::create(filename).unwrap();
-            serde_json::to_writer_pretty(f, &data).unwrap();
+            let f = BufWriter::new(File::create(filename).unwrap());
+            serde_json::to_writer(f, &data).unwrap();
         }
     }
 


### PR DESCRIPTION
Serde serializes through tiny writes so essential to use BufWriter as File is unbuffered. 

This reduces writing down a 4.1 MB JSON profile report from 12840 ms to 168 ms. 

Also pretty printing is not important for this output nor for Chrome so disabled that as well and got down the total serialization time from 12840 ms to 107 ms. 

Not too shabby with a 120x speed of write_profile  for a simple 2 line change!