### PR TITLE
Prepend module_path to traces

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,3 @@ lazy_static = { version = "1", optional = true }
 
 [features]
 thread_profiler = ["time", "serde_json", "lazy_static"]
-prepend_module_path = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,4 @@ lazy_static = { version = "1", optional = true }
 
 [features]
 thread_profiler = ["time", "serde_json", "lazy_static"]
+prepend_module_path = []

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,0 +1,68 @@
+/// A simple example showing how
+/// to use a thread_profiler
+/// to profile a long running function
+/// in a single thread.
+///
+/// The outputted profile will be something like
+///
+/// 'simple: covering function'
+///     |  
+/// ____V________________________
+/// |____________________________|         
+///  |____________|_____________|
+///     ^             ^
+///     |           'simple: section 2'
+/// 'simple: section_1'
+
+#[macro_use]
+extern crate thread_profiler;
+
+use std::vec::Vec;
+
+fn main() {
+    if !cfg!(feature = "thread_profiler") {
+        println!("Enable the thread_profiler feature. Exiting.");
+        return;
+    }
+    println!(
+        "Running with thread_profler. Names prepended by '{}'",
+        module_path!()
+    );
+
+    // Register this thread with the profiler.
+    thread_profiler::register_thread_with_profiler();
+    #[cfg(feature = "thread_profiler")]
+    long_complex_function();
+    // Write the profile to a file
+    thread_profiler::write_profile("./profile.json");
+}
+
+fn long_complex_function() {
+    // This will create a profile scope called
+    // 'simple' as this is the name of the module.
+    profile_scope!("covering function");
+    let mut v = Vec::new();
+    {
+        // This will create a profile scope called
+        // 'simple: section_1', i.e. the name of the
+        // module with a comment describing the profile.
+
+        profile_scope!("section 1");
+        // Do complex work
+        v.push(1);
+        // Drop is called on
+        // 'simple: section_1'
+    }
+    {
+        // This will create a profile scope called
+        // 'simple: section_2'
+        profile_scope!("section 2");
+        // Do complex work
+        v.push(2);
+        // Drop is called on
+        // 'simple: section_2'
+    }
+    v.push(3)
+    // Drop is called on
+    // 'simple'
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,8 +26,7 @@ mod internal {
     #[macro_export]
     macro_rules! profile_scope {
         ($string:expr) => {
-            let _pname = format!("{}: {}", module_path!(), $string);
-            let _profile_scope = $crate::ProfileScope::new(_pname);
+            let _profile_scope = $crate::ProfileScope::new(format!("{}: {}", module_path!(), $string));
         };
     }
 


### PR DESCRIPTION
Tracked in #12 

Documentation: Added in an example showing the basic usage of the crate. This example can be run with `cargo run --example simple --features thread_profiler`

Breaking: Changed the types used to store the thread names from `&'static str` to `std::string::String`. This was to allow pretending the module name as I'm not sure how this could have been worked out at compile time.

Formatting: cargo fmt'd the crate.